### PR TITLE
Potential fix for code scanning alert no. 1: Code injection

### DIFF
--- a/deployy.py
+++ b/deployy.py
@@ -189,13 +189,13 @@ if "prediction" not in st.session_state:
 
 def predict():
     try:
-        wafer_map = np.array(eval(x))
+        wafer_map = np.array(json.loads(x))
         st.session_state.wafer_shape = wafer_map.shape
         preprocessed_data = preprocess_wafer_data(wafer_map)
         st.session_state.prediction = model.predict(preprocessed_data)[0]
         st.session_state.wafer_map = wafer_map  # Store for plotting
-    except Exception as e:
-        st.session_state.prediction = f"⚠️ Error: {e}"
+    except (json.JSONDecodeError, ValueError) as e:
+        st.session_state.prediction = f"⚠️ Error: Invalid input format. Please enter a valid JSON array. ({e})"
         st.session_state.wafer_map = None
 
 st.button("🔍 Predict", on_click=predict)


### PR DESCRIPTION
Potential fix for [https://github.com/ambruhsia/semicon-wafer-inspectt/security/code-scanning/1](https://github.com/ambruhsia/semicon-wafer-inspectt/security/code-scanning/1)

To fix the issue, we need to replace the use of `eval` with a safer alternative. Since the input is expected to be a list of lists (representing a wafer map), we can use `json.loads` to parse the input as JSON. This approach ensures that only valid JSON data is accepted, preventing code injection.

**Steps to fix:**
1. Replace the `eval` function with `json.loads` to safely parse the user input.
2. Add error handling to ensure that invalid JSON input is gracefully handled.
3. Update the `predict` function to reflect these changes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
